### PR TITLE
Fix the failed test in Ruby 2.1.5

### DIFF
--- a/backend/app/helpers/comable/admin/themes_helper.rb
+++ b/backend/app/helpers/comable/admin/themes_helper.rb
@@ -20,7 +20,7 @@ module Comable
       private
 
       def views_dir
-        spec = Gem::Specification.find_by_name('comable-frontend')
+        spec = Gem::Specification.find_by_path('comable/frontend')
         fail 'Please install "comable-frontend" gem!' unless spec
         "#{spec.gem_dir}/app/views"
       end


### PR DESCRIPTION
Fix the failed test because could not find comable-frontend gem of beta version.
Please see the below url for details of the error.

`Please install "comable-frontend" gem!'` error:
https://travis-ci.org/appirits/comable/jobs/82083564#L4564
