### PR TITLE
Fix a problem that create a duplicate address

### DIFF
--- a/backend/spec/controllers/comable/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/comable/admin/orders_controller_spec.rb
@@ -66,6 +66,18 @@ describe Comable::Admin::OrdersController do
         expect(response).to render_template(:edit)
       end
     end
+
+    describe 'with valid params for address' do
+      let(:bill_address_attributes) { { family_name: "NEW: #{order.bill_address.family_name}" } }
+      let(:new_attributes) { { bill_address_attributes: bill_address_attributes.merge(id: order.bill_address.to_param) } }
+
+      pending 'updates the address of requested order' do
+        bill_address = order.bill_address
+        put :update, id: order.to_param, order: new_attributes
+        bill_address.reload
+        expect(bill_address).to have_attributes(bill_address_attributes)
+      end
+    end
   end
 
   describe 'GET export' do

--- a/backend/spec/controllers/comable/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/comable/admin/orders_controller_spec.rb
@@ -71,7 +71,7 @@ describe Comable::Admin::OrdersController do
       let(:bill_address_attributes) { { family_name: "NEW: #{order.bill_address.family_name}" } }
       let(:new_attributes) { { bill_address_attributes: bill_address_attributes.merge(id: order.bill_address.to_param) } }
 
-      pending 'updates the address of requested order' do
+      it 'updates the address of requested order' do
         bill_address = order.bill_address
         put :update, id: order.to_param, order: new_attributes
         bill_address.reload

--- a/core/app/controllers/concerns/comable/permitted_attributes.rb
+++ b/core/app/controllers/concerns/comable/permitted_attributes.rb
@@ -2,6 +2,7 @@ module Comable
   module PermittedAttributes
     def permitted_address_attributes
       [
+        :id,
         :family_name,
         :first_name,
         :zip_code,


### PR DESCRIPTION
The controller creates a duplicate address because the address ID is not permitted to update.
